### PR TITLE
luci-app-ipsec-server:add kmod-tun

### DIFF
--- a/luci-app-ipsec-server/Makefile
+++ b/luci-app-ipsec-server/Makefile
@@ -6,7 +6,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for IPSec VPN Server
-LUCI_DEPENDS:=+strongswan +strongswan-minimal +strongswan-mod-kernel-libipsec +strongswan-mod-openssl +strongswan-mod-xauth-generic +xl2tpd +luci-lib-jsonc
+LUCI_DEPENDS:=+strongswan +strongswan-minimal +strongswan-mod-kernel-libipsec +strongswan-mod-openssl +strongswan-mod-xauth-generic +xl2tpd +luci-lib-jsonc +kmod-tun
 LUCI_PKGARCH:=all
 PKG_VERSION:=20211216
 PKG_RELEASE:=1


### PR DESCRIPTION
解决若缺少依赖包 kmod-tun，固件接口总览中IPSEC_SERVER（ipsec0）接口状态无法启动问题。
https://github.com/Lienol/openwrt-package/issues/5