### PR TITLE
文件助手改进

### DIFF
--- a/luci-app-fileassistant/Makefile
+++ b/luci-app-fileassistant/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Fileassistant
 LUCI_PKGARCH:=all
-PKG_VERSION:=1.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.0-3
+PKG_RELEASE:=
 
 include $(TOPDIR)/feeds/luci/luci.mk
 

--- a/luci-app-fileassistant/Makefile
+++ b/luci-app-fileassistant/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Fileassistant
 LUCI_PKGARCH:=all
-PKG_VERSION:=1.0-3
+PKG_VERSION:=1.0-4
 PKG_RELEASE:=
 
 include $(TOPDIR)/feeds/luci/luci.mk

--- a/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
+++ b/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
@@ -156,7 +156,14 @@ String.prototype.replaceAll = function(search, replacement) {
     }
   }
   function refresh_list(filenames, path) {
-    var listHtml = '<table class="cbi-section-table"><tbody>';
+    var listHtml = '<table class="cbi-section-table"><thead><tr class="cbi-section-table-row cbi-rowstyle-2">'
+      +'<td class="cbi-value-field">文件</td>'
+      +'<td class="cbi-value-field">所有者</td>'
+      +'<td class="cbi-value-field">修改时间</td>'
+      +'<td class="cbi-value-field">大小</td>'
+      +'<td class="cbi-value-field">权限</td>'
+      +'<td class="cbi-section-table-cell">操作</td>'
+      +'</tr></thead><tbody>';
     if (path !== '/') {
       listHtml += '<tr class="cbi-section-table-row cbi-rowstyle-2"><td class="parent-icon" colspan="6"><strong>..</strong></td></tr>';
     }

--- a/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
+++ b/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
@@ -91,6 +91,23 @@ String.prototype.replaceAll = function(search, replacement) {
     }
   }
 
+  function chmodPath(filename, isdir) {
+    var newmod = prompt('请输入新的权限位（支持八进制权限位或者a+x格式）：', isdir === "1" ? "0755" : "0644");
+    if (newmod) {
+      iwxhr.get('/cgi-bin/luci/admin/nas/fileassistant/chmod',
+        {
+          filepath: concatPath(currentPath, filename),
+          newmod: newmod
+        },
+        function (x, res) {
+          if (res.ec === 0) {
+            refresh_list(res.data, currentPath);
+          }
+        }
+      );
+    }
+  }
+
   function openpath(filename, dirname) {
     dirname = dirname || currentPath;
     window.open('/cgi-bin/luci/admin/nas/fileassistant/open?path='
@@ -129,6 +146,10 @@ String.prototype.replaceAll = function(search, replacement) {
     }
     else if (targetElem.className.indexOf('cbi-button-edit') > -1) {
       renamePath(targetElem.parentNode.parentNode.dataset['filename']);
+    }
+    else if (targetElem.className.indexOf('cbi-button-chmod') > -1) {
+      infoElem = targetElem.parentNode.parentNode;
+      chmodPath(infoElem.dataset['filename'] , infoElem.dataset['isdir']);
     }
     else if (targetElem = getFileElem(targetElem)) {
       if (targetElem.className.indexOf('parent-icon') > -1) {
@@ -203,7 +224,8 @@ String.prototype.replaceAll = function(search, replacement) {
             + '<td class="cbi-value-field cbi-value-perm">'+o.perms+'</td>'
             + '<td class="cbi-section-table-cell">\
 				<button class="cbi-button cbi-button-edit">重命名</button>\
-                <button class="cbi-button cbi-button-remove">删除</button>'
+                <button class="cbi-button cbi-button-remove">删除</button>\
+                <button class="cbi-button cbi-button-apply cbi-button-chmod">改权限</button>'
 			+ install_btn
 			+ '</td>'
             + '</tr>';

--- a/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
+++ b/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
@@ -108,6 +108,23 @@ String.prototype.replaceAll = function(search, replacement) {
     }
   }
 
+  function chownPath(filename) {
+    var newown = prompt('请输入新的用户名（支持用户名或用户名:群组格式）：', "root");
+    if (newown) {
+      iwxhr.get('/cgi-bin/luci/admin/nas/fileassistant/chown',
+        {
+          filepath: concatPath(currentPath, filename),
+          newown: newown
+        },
+        function (x, res) {
+          if (res.ec === 0) {
+            refresh_list(res.data, currentPath);
+          }
+        }
+      );
+    }
+  }
+
   function openpath(filename, dirname) {
     dirname = dirname || currentPath;
     window.open('/cgi-bin/luci/admin/nas/fileassistant/open?path='
@@ -150,6 +167,9 @@ String.prototype.replaceAll = function(search, replacement) {
     else if (targetElem.className.indexOf('cbi-button-chmod') > -1) {
       infoElem = targetElem.parentNode.parentNode;
       chmodPath(infoElem.dataset['filename'] , infoElem.dataset['isdir']);
+    }
+    else if (targetElem.className.indexOf('cbi-button-chown') > -1) {
+      chownPath(targetElem.parentNode.parentNode.dataset['filename']);
     }
     else if (targetElem = getFileElem(targetElem)) {
       if (targetElem.className.indexOf('parent-icon') > -1) {
@@ -225,7 +245,8 @@ String.prototype.replaceAll = function(search, replacement) {
             + '<td class="cbi-section-table-cell">\
 				<button class="cbi-button cbi-button-edit">重命名</button>\
                 <button class="cbi-button cbi-button-remove">删除</button>\
-                <button class="cbi-button cbi-button-apply cbi-button-chmod">改权限</button>'
+                <button class="cbi-button cbi-button-apply cbi-button-chmod">改权限</button>\
+                <button class="cbi-button cbi-button-apply cbi-button-chown">改用户</button>'
 			+ install_btn
 			+ '</td>'
             + '</tr>';

--- a/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
+++ b/luci-app-fileassistant/htdocs/luci-static/resources/fileassistant/fb.js
@@ -277,6 +277,26 @@ String.prototype.replaceAll = function(search, replacement) {
     }
   };
 
+  document.getElementById('mkdir-toggle').onclick = function() {
+    var dirname = null;
+    if (dirname = prompt("请输入文件夹名称：")) {
+      var formData = new FormData();
+      formData.append('path', currentPath);
+      formData.append('dirname', dirname);
+      var xhr = new XMLHttpRequest();
+      xhr.open("POST", "/cgi-bin/luci/admin/nas/fileassistant/mkdir", true);
+      xhr.onload = function() {
+        if (xhr.status == 200) {
+          var res = JSON.parse(xhr.responseText);
+          refresh_list(res.data, currentPath);
+        }
+        else {
+          alert('创建失败，请稍后再试...');
+        }
+      };
+      xhr.send(formData);
+    }
+  };
   document.addEventListener('DOMContentLoaded', function(evt) {
     var initPath = '/';
     if (/path=([/\w]+)/.test(location.search)) {

--- a/luci-app-fileassistant/luasrc/controller/fileassistant.lua
+++ b/luci-app-fileassistant/luasrc/controller/fileassistant.lua
@@ -27,6 +27,8 @@ function index()
     page = entry({"admin", "nas", "fileassistant", "install"}, call("fileassistant_install"), nil)
     page.leaf = true
 
+    page = entry({"admin", "nas", "fileassistant", "mkdir"}, call("fileassistant_mkdir"), nil)
+    page.leaf = true
 end
 
 function list_response(path, success)
@@ -131,6 +133,13 @@ function fileassistant_upload()
     )
 
     list_response(uploaddir, true)
+end
+
+function fileassistant_mkdir()
+    local path = luci.http.formvalue("path")
+    local dirname = luci.http.formvalue("dirname")
+    local success = os.execute('sh -c \'cd "'..path..'" && mkdir -p "'..dirname..'"\'')
+    list_response(path, success)
 end
 
 function scandir(directory)

--- a/luci-app-fileassistant/luasrc/controller/fileassistant.lua
+++ b/luci-app-fileassistant/luasrc/controller/fileassistant.lua
@@ -32,6 +32,9 @@ function index()
 
     page = entry({"admin", "nas", "fileassistant", "chmod"}, call("fileassistant_chmod"), nil)
     page.leaf = true
+
+    page = entry({"admin", "nas", "fileassistant", "chown"}, call("fileassistant_chown"), nil)
+    page.leaf = true
 end
 
 function list_response(path, success)
@@ -149,6 +152,13 @@ function fileassistant_chmod()
     local path = luci.http.formvalue("filepath")
     local newmod = luci.http.formvalue("newmod")
     local success = os.execute('chmod '..newmod..' "'..path..'"')
+    list_response(nixio.fs.dirname(path), success)
+end
+
+function fileassistant_chown()
+    local path = luci.http.formvalue("filepath")
+    local newown = luci.http.formvalue("newown")
+    local success = os.execute('chown '..newown..' "'..path..'"')
     list_response(nixio.fs.dirname(path), success)
 end
 

--- a/luci-app-fileassistant/luasrc/controller/fileassistant.lua
+++ b/luci-app-fileassistant/luasrc/controller/fileassistant.lua
@@ -29,6 +29,9 @@ function index()
 
     page = entry({"admin", "nas", "fileassistant", "mkdir"}, call("fileassistant_mkdir"), nil)
     page.leaf = true
+
+    page = entry({"admin", "nas", "fileassistant", "chmod"}, call("fileassistant_chmod"), nil)
+    page.leaf = true
 end
 
 function list_response(path, success)
@@ -140,6 +143,13 @@ function fileassistant_mkdir()
     local dirname = luci.http.formvalue("dirname")
     local success = os.execute('sh -c \'cd "'..path..'" && mkdir -p "'..dirname..'"\'')
     list_response(path, success)
+end
+
+function fileassistant_chmod()
+    local path = luci.http.formvalue("filepath")
+    local newmod = luci.http.formvalue("newmod")
+    local success = os.execute('chmod '..newmod..' "'..path..'"')
+    list_response(nixio.fs.dirname(path), success)
 end
 
 function scandir(directory)

--- a/luci-app-fileassistant/luasrc/view/fileassistant.htm
+++ b/luci-app-fileassistant/luasrc/view/fileassistant.htm
@@ -7,6 +7,7 @@
   <div class="panel-container">
     <div class="panel-title">文件列表</div>
     <button id="upload-toggle" class="upload-toggle cbi-button cbi-button-edit">上传</button>
+    <button id="mkdir-toggle" class="upload-toggle cbi-button cbi-button-edit">新建文件夹&hellip; </button>
   </div>
   <div class="upload-container" id="upload-container">
     <input id="upload-file" name="upload-file" class="upload-file" type="file">

--- a/luci-app-fileassistant/luasrc/view/fileassistant.htm
+++ b/luci-app-fileassistant/luasrc/view/fileassistant.htm
@@ -1,6 +1,6 @@
 <%+header%>
 
-<link rel="stylesheet" href="/luci-static/resources/fileassistant/fb.css?v=@ver">
+<link rel="stylesheet" href="/luci-static/resources/fileassistant/fb.css<%# ?v=PKG_VERSION %>">
 <h2 name="content">文件助手</h2>
 <fieldset class="cbi-section fb-container">
   <input id="current-path" type="text" class="current-path cbi-input-text" value="/"/>
@@ -15,6 +15,6 @@
   <div id="list-content"></div>
 </fieldset>
 
-<script src="/luci-static/resources/fileassistant/fb.js?v=@ver"></script>
+<script src="/luci-static/resources/fileassistant/fb.js<%# ?v=PKG_VERSION %>"></script>
 
 <%+footer%>


### PR DESCRIPTION
* css和js版本号通过PKG_VERSION注入（可能需要21版sdk支持）
* 文件列表增加了标题栏
* 增加以下功能：
  1. 新建文件夹
  2. chmod文件（夹）
  3. chown文件（夹）