### PR TITLE
luci-app-fileassistant: setfilehandler before formvalue

### DIFF
--- a/luci-app-fileassistant/Makefile
+++ b/luci-app-fileassistant/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Fileassistant
 LUCI_PKGARCH:=all
-PKG_VERSION:=1.0-4
+PKG_VERSION:=1.0-5
 PKG_RELEASE:=
 
 include $(TOPDIR)/feeds/luci/luci.mk

--- a/luci-app-fileassistant/luasrc/controller/fileassistant.lua
+++ b/luci-app-fileassistant/luasrc/controller/fileassistant.lua
@@ -118,15 +118,18 @@ function installIPK(filepath)
 end
 
 function fileassistant_upload()
-    local filecontent = luci.http.formvalue("upload-file")
-    local filename = luci.http.formvalue("upload-filename")
-    local uploaddir = luci.http.formvalue("upload-dir")
-    local filepath = uploaddir..filename
-
     local fp
+    -- MUST setfilehandler before formvalue,
+    -- beacuse formvalue will parse form and write body to /tmp if filehandler not present
     luci.http.setfilehandler(
         function(meta, chunk, eof)
             if not fp and meta and meta.name == "upload-file" then
+                local filename = luci.http.formvalue("upload-filename")
+                local uploaddir = luci.http.formvalue("upload-dir")
+                if not uploaddir or not filename then
+                    error("uploaddir or filename is nil")
+                end
+                local filepath = uploaddir..filename
                 fp = io.open(filepath, "w")
             end
             if fp and chunk then
@@ -138,7 +141,7 @@ function fileassistant_upload()
       end
     )
 
-    list_response(uploaddir, true)
+    list_response(luci.http.formvalue("upload-dir"), true)
 end
 
 function fileassistant_mkdir()


### PR DESCRIPTION
在formvalue之前调用setfilehandler。
formvalue会解析表单和body，如果filehandler还没设置的话，body会被写到/tmp/文件夹下，等到setfilehandler时才拷贝到目标位置。由于/tmp是内存空间，上传大文件可能导致内存耗尽死机。先调用setfilehandler的话就不会有这个问题。